### PR TITLE
Add Install Workflow

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install GCC 11
-        run: sudo apt update && sudo apt install -y gcc-11
+        run: sudo apt update && sudo apt install -y gcc-11 pandoc
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install ranges


### PR DESCRIPTION
Add github install workflow that builds and installs ranges, checks if the command is runnable and the manpage accessible, removes it again and checks both don't work anymore.

Resolves #56