### PR TITLE
Fix TTY Input Test

### DIFF
--- a/test/options.bats
+++ b/test/options.bats
@@ -50,6 +50,9 @@ setup() {
 }
 
 @test "ranges with tty input causes 'no input error'" {
+    if [ ! -z "${RUNNER_OS}" ]; then
+        skip "/dev/tty is not accessible in GitHub runner"
+    fi
     if [ ! -c /dev/tty ]; then
         skip "no /dev/tty device"
     fi


### PR DESCRIPTION
Replaced the `-f` check in the options test for tty input by `-c /dev/tty` because this is a character device.

Fixes #68